### PR TITLE
Rename EditorGame to Composer & composer.Tests to composer.Editor.Tests

### DIFF
--- a/composer.Desktop/ComposerDesktop.cs
+++ b/composer.Desktop/ComposerDesktop.cs
@@ -4,7 +4,7 @@ using osu.Framework.Platform;
 
 namespace composer.Desktop
 {
-    public partial class ComposerDesktop : EditorGame
+    public partial class ComposerDesktop : Composer
     {
         public ComposerDesktop()
         {

--- a/composer.Editor/Composer.cs
+++ b/composer.Editor/Composer.cs
@@ -11,7 +11,7 @@ using osuTK.Graphics;
 
 namespace composer.Editor
 {
-    public partial class EditorGame : OsuGameBase
+    public partial class Composer : OsuGameBase
     {
         private Container content = null!;
 

--- a/composer.Tests/Visual/TestSceneComposer.cs
+++ b/composer.Tests/Visual/TestSceneComposer.cs
@@ -9,7 +9,7 @@ namespace composer.Tests.Visual
         [BackgroundDependencyLoader]
         private void load()
         {
-            AddGame(new EditorGame());
+            AddGame(new Composer());
         }
     }
 }


### PR DESCRIPTION
far more consistent with the name of the project and `composer.Tests` shouldn't have been named what it was anyways