### PR TITLE
Create beatmap card drawable

### DIFF
--- a/composer.Editor.Tests/Visual/Select/TestSceneBeatmapCard.cs
+++ b/composer.Editor.Tests/Visual/Select/TestSceneBeatmapCard.cs
@@ -1,0 +1,68 @@
+﻿using composer.Editor.Screens.Select.Carousel;
+using composer.Editor.Tests.Resources;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Utils;
+using osu.Game.Rulesets.Catch;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Taiko;
+using osu.Game.Tests.Visual;
+using osuTK;
+
+namespace composer.Editor.Tests.Visual.Select
+{
+    public partial class TestSceneBeatmapCard : OsuTestScene
+    {
+        [Test]
+        public void Card()
+        {
+            var info = TestResources.CreateTestBeatmapSetInfo(null,
+                new[] { new OsuRuleset().RulesetInfo, new TaikoRuleset().RulesetInfo, new CatchRuleset().RulesetInfo, new ManiaRuleset().RulesetInfo });
+
+            var cards = new List<BeatmapCard>();
+            BeatmapCard? selectedCard = null;
+            
+            AddStep("clear screen", Clear);
+            AddStep("add cards", () =>
+            {
+                var flow = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.Y,
+                    Width = 720,
+                    Direction = FillDirection.Vertical,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Spacing = new Vector2(8)
+                };
+                
+                Add(flow);
+                
+                foreach (var beatmap in info.Beatmaps)
+                {
+                    var card = new BeatmapCard(beatmap)
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = 45,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre
+                    };
+                    
+                    flow.Add(card);
+                    cards.Add(card);
+                }
+            });
+
+            AddStep("select random", () =>
+            {
+                if (selectedCard != null)
+                    selectedCard.State.Value = false;
+
+                var card = cards[RNG.Next(cards.Count)];
+                card.State.Value = true;
+                selectedCard = card;
+            });
+        }
+    }
+}

--- a/composer.Editor/Graphics/ComposerColour.cs
+++ b/composer.Editor/Graphics/ComposerColour.cs
@@ -1,0 +1,22 @@
+﻿using osuTK.Graphics;
+
+namespace composer.Editor.Graphics
+{
+    public static class ComposerColour
+    {
+        public static Color4 Gray(float amt) => new Color4(amt, amt, amt, 1f);
+        public static Color4 Gray(byte amt) => new Color4(amt, amt, amt, 255);
+        
+        /// <summary>
+        /// Returns a foreground text colour that is supposed to contrast well with
+        /// the supplied <paramref name="backgroundColour"/>.
+        /// </summary>
+        public static Color4 ForegroundTextColourFor(Color4 backgroundColour, byte dark = 51, byte light = 229)
+        {
+            // formula taken from the RGB->YIQ conversions: https://en.wikipedia.org/wiki/YIQ
+            // brightness here is equivalent to the Y component in the above colour model, which is a rough estimate of lightness.
+            float brightness = 0.299f * backgroundColour.R + 0.587f * backgroundColour.G + 0.114f * backgroundColour.B;
+            return Gray(brightness > 0.5f ? dark : light);
+        }
+    }
+}

--- a/composer.Editor/Screens/Select/Carousel/BeatmapCard.cs
+++ b/composer.Editor/Screens/Select/Carousel/BeatmapCard.cs
@@ -1,0 +1,218 @@
+﻿using composer.Editor.Graphics;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osuTK;
+using osuTK.Graphics;
+
+namespace composer.Editor.Screens.Select.Carousel
+{
+    public partial class BeatmapCard : CompositeDrawable
+    {
+        private const float width_selected = 0.85f;
+        private const float width_normal = 0.75f;
+        private const float content_height_normal = 1f;
+        private const float content_height_selected = 0.925f;
+
+        private readonly BeatmapInfo info;
+
+        private Container infoContainer = null!;
+        private Container contentContainer = null!;
+        private OsuTextFlowContainer mappedText = null!;
+
+        // todo: move this to a more generalized form in order to let BeatmapSetCard to have the same logic.
+        //       ~ Nora
+        public BindableBool State { get; } = new();
+
+        public BeatmapCard(BeatmapInfo info)
+        {
+            this.info = info;
+        }
+
+        [Resolved]
+        private OsuColour colour { get; set; } = null!;
+
+        private Color4 getDifficultyColour()
+            => info.StarRating >= 9f ? OsuColour.Gray(26) : colour.ForStarDifficulty(info.StarRating);
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChild = contentContainer = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Width = width_normal,
+                Anchor = Anchor.CentreRight,
+                Origin = Anchor.CentreRight,
+                Masking = true,
+                CornerRadius = 5,
+                Children = new[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = getDifficultyColour()
+                    },
+                    info.Ruleset.CreateInstance().CreateIcon().With(d =>
+                    {
+                        d.Size = new Vector2(20);
+                        d.Anchor = Anchor.CentreLeft;
+                        d.Origin = Anchor.CentreLeft;
+                        d.X = 7;
+                        d.Colour = ComposerColour.ForegroundTextColourFor(getDifficultyColour(), 13);
+                    }),
+                    infoContainer = new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Height = content_height_normal,
+                        Width = 0.94f,
+                        Anchor = Anchor.TopRight,
+                        Origin = Anchor.TopRight,
+                        Masking = true,
+                        CornerRadius = 5,
+                        // Fixes weird vertical scissoring issue with o!f
+                        Y = -0.2f,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = OsuColour.Gray(10)
+                            },
+                            new FillFlowContainer
+                            {
+                                Direction = FillDirection.Vertical,
+                                Padding = new MarginPadding { Vertical = 4, Horizontal = 8 },
+                                Spacing = new Vector2(0, 4),
+                                Anchor = Anchor.CentreLeft,
+                                Origin = Anchor.CentreLeft,
+                                RelativeSizeAxes = Axes.Both,
+                                Children = new Drawable[]
+                                {
+                                    new FillFlowContainer
+                                    {
+                                        Direction = FillDirection.Horizontal,
+                                        RelativeSizeAxes = Axes.X,
+                                        AutoSizeAxes = Axes.Y,
+                                        Spacing = new Vector2(8),
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft,
+                                        Children = new Drawable[]
+                                        {
+                                            new DifficultyPill(info.StarRating),
+                                            mappedText = new OsuTextFlowContainer(c => c.Font = OsuFont.GetFont(Typeface.Inter, 12))
+                                            {
+                                                RelativeSizeAxes = Axes.X,
+                                                AutoSizeAxes = Axes.Y,
+                                                Colour = OsuColour.Gray(153)
+                                            }
+                                        }
+                                    },
+                                    new Container
+                                    {
+                                        RelativeSizeAxes = Axes.X,
+                                        AutoSizeAxes = Axes.Y,
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft,
+                                        Child = new OsuSpriteText
+                                        {
+                                            Font = OsuFont.GetFont(Typeface.Inter, weight: FontWeight.SemiBold),
+                                            Text = info.DifficultyName
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            mappedText.AddText("mapped by ");
+            mappedText.AddText(info.Metadata.Author.Username, c => c.Font = OsuFont.GetFont(Typeface.Inter, 12, FontWeight.Bold));
+
+            State.BindValueChanged(onStateChange);
+        }
+
+        private void onStateChange(ValueChangedEvent<bool> val)
+        {
+            if (val.NewValue)
+                Selected();
+            else
+                Deselected();
+        }
+
+        private void Selected()
+        {
+            contentContainer.ResizeWidthTo(width_selected, 500, Easing.OutQuint);
+            infoContainer.ResizeHeightTo(content_height_selected, 500, Easing.OutQuint);
+            contentContainer.EdgeEffect = new EdgeEffectParameters
+            {
+                Type = EdgeEffectType.Glow,
+                Colour = getDifficultyColour().Opacity(0.25f),
+                Radius = 12,
+                Roundness = 5,
+            };
+        }
+
+        private void Deselected()
+        {
+            contentContainer.ResizeWidthTo(width_normal, 500, Easing.OutQuint);
+            infoContainer.ResizeHeightTo(content_height_normal, 500, Easing.OutQuint);
+            contentContainer.EdgeEffect = new EdgeEffectParameters
+            {
+                Type = EdgeEffectType.Glow,
+                Colour = getDifficultyColour().Opacity(0.25f),
+                Radius = 0,
+                Roundness = 5,
+            };
+        }
+
+        private partial class DifficultyPill : CompositeDrawable
+        {
+            private readonly double starRating;
+
+            public DifficultyPill(double starRating)
+            {
+                this.starRating = starRating;
+                AutoSizeAxes = Axes.Both;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colour)
+            {
+                var col = starRating >= 9f ? OsuColour.Gray(26) : colour.ForStarDifficulty(starRating);
+
+                InternalChild = new CircularContainer
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Masking = true,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = col
+                        },
+                        new OsuSpriteText
+                        {
+                            Font = OsuFont.GetFont(Typeface.Inter, 12, FontWeight.Bold),
+                            Text = starRating.ToString("N2"),
+                            Margin = new MarginPadding { Horizontal = 8 },
+                            Colour = ComposerColour.ForegroundTextColourFor(col, 13)
+                        }
+                    }
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
![dotnet_5dp7cLzzQN](https://user-images.githubusercontent.com/35349837/219478042-8cb2fa94-47c9-4679-82d0-47c2b0226ed2.gif)

Simple enough. Eventually, I want to generalize both `BeatmapCard` and `BeatmapSetCard` to handle selection and other areas that would ultimately come with the carousel selection.