### PR TITLE
Add license headers to code that was directly borrowed from lazer

### DIFF
--- a/composer.Editor.Tests/Resources/TestResources.cs
+++ b/composer.Editor.Tests/Resources/TestResources.cs
@@ -1,4 +1,7 @@
-﻿using System.Text;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Text;
 using osu.Framework.Extensions;
 using osu.Framework.Logging;
 using osu.Framework.Utils;

--- a/composer.Editor/Screens/Select/BeatmapCarousel.cs
+++ b/composer.Editor/Screens/Select/BeatmapCarousel.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics;
 using composer.Editor.Input;
 using composer.Editor.Screens.Select.Carousel;
 using osu.Framework.Allocation;

--- a/composer.Editor/Screens/Select/BeatmapSelect.cs
+++ b/composer.Editor/Screens/Select/BeatmapSelect.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics;
 using composer.Editor.Input;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;

--- a/composer.Editor/Screens/Select/Carousel/BeatmapSetPanelBackground.cs
+++ b/composer.Editor/Screens/Select/Carousel/BeatmapSetPanelBackground.cs
@@ -1,4 +1,7 @@
-﻿using osu.Framework.Extensions.Color4Extensions;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;

--- a/composer.Editor/Screens/Select/Carousel/BeatmapSetPanelContent.cs
+++ b/composer.Editor/Screens/Select/Carousel/BeatmapSetPanelContent.cs
@@ -1,4 +1,7 @@
-﻿using osu.Framework.Allocation;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/composer.Editor/Screens/Select/Carousel/CarouselHeader.cs
+++ b/composer.Editor/Screens/Select/Carousel/CarouselHeader.cs
@@ -1,4 +1,7 @@
-﻿using osu.Framework.Allocation;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;

--- a/composer.Editor/Screens/Select/Carousel/DrawableCarouselBeatmapCard.cs
+++ b/composer.Editor/Screens/Select/Carousel/DrawableCarouselBeatmapCard.cs
@@ -1,4 +1,7 @@
-﻿using composer.Editor.Graphics;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using composer.Editor.Graphics;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;

--- a/composer.Editor/Screens/Select/Carousel/DrawableCarouselBeatmapSetCard.cs
+++ b/composer.Editor/Screens/Select/Carousel/DrawableCarouselBeatmapSetCard.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;

--- a/composer.Editor/Screens/Select/Carousel/DrawableCarouselItem.cs
+++ b/composer.Editor/Screens/Select/Carousel/DrawableCarouselItem.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/composer.Editor/Screens/Select/FilterQueryParser.cs
+++ b/composer.Editor/Screens/Select/FilterQueryParser.cs
@@ -1,4 +1,7 @@
-﻿using System.Globalization;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Globalization;
 using System.Text.RegularExpressions;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;


### PR DESCRIPTION
Following up on ppy's notice on Twitter. https://twitter.com/ppy/status/1633330717689257984?s=20
> ...but one thing to note is to please leave the license headers in place on all the files that you are borrowing from lazer!!